### PR TITLE
Zero Downtime Elasticsearch Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 exlasticsearch-*.tar
 
+.elixir_ls/

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Exlasticsearch.MixProject do
   use Mix.Project
 
-  @version "1.4.0"
+  @version "1.5.0"
 
   def project do
     [


### PR DESCRIPTION

Introduce read/write versions so you can read from an existing index
while reindexing against a new one.