### PR TITLE
Index rotation in elasticsearch

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Exlasticsearch.MixProject do
   use Mix.Project
 
-  @version "1.5.2"
+  @version "1.5.3"
 
   def project do
     [

--- a/test/exlasticsearch/repo_test.exs
+++ b/test/exlasticsearch/repo_test.exs
@@ -2,12 +2,20 @@ defmodule ExlasticSearch.RepoTest do
   use ExUnit.Case, async: true
   alias ExlasticSearch.{
     Repo,
-    TestModel
+    TestModel,
+
   }
+  alias ExlasticSearch.MultiVersionTestModel, as: MVTestModel
 
   setup_all do
     Repo.create_index(TestModel)
     Repo.create_mapping(TestModel)
+
+    Repo.create_index(MVTestModel)
+    Repo.create_mapping(MVTestModel)
+
+    Repo.create_index(MVTestModel, :read)
+    Repo.create_mapping(MVTestModel, :read)
     :ok
   end
 
@@ -24,6 +32,17 @@ defmodule ExlasticSearch.RepoTest do
     test "It will bulk index/delete from es" do
       model = %ExlasticSearch.TestModel{id: Ecto.UUID.generate()}
       {:ok, _} = Repo.bulk([{:index, model}])
+
+      assert exists?(model)
+    end
+  end
+
+  describe "#rotate" do
+    test "It can deprecate an old index version" do
+      model = %MVTestModel{id: Ecto.UUID.generate()}
+      {:ok, _} = Repo.index(model)
+
+      Repo.rotate(MVTestModel)
 
       assert exists?(model)
     end

--- a/test/support/test_model.ex
+++ b/test/support/test_model.ex
@@ -18,7 +18,27 @@ defmodule ExlasticSearch.TestModel do
   end
 end
 
-defimpl ExlasticSearch.Indexable, for: ExlasticSearch.TestModel do
+defmodule ExlasticSearch.MultiVersionTestModel do
+  use Ecto.Schema
+  use ExlasticSearch.Model
+
+  schema "mv_models" do
+    field :name, :string
+    field :age, :integer, default: 0
+  end
+
+  indexes :multiversion_model do
+    versions {:ignore, 2}
+    settings %{}
+    options %{dynamic: :strict}
+    mapping :name
+    mapping :age
+
+    mapping :user, properties: %{ext_name: %{type: :text}}
+  end
+end
+
+defimpl ExlasticSearch.Indexable, for: [ExlasticSearch.TestModel, ExlasticSearch.MultiVersionTestModel] do
   def id(%{id: id}), do: id
 
   def document(struct) do


### PR DESCRIPTION

Use an alias to redirect traffic from a read index to a write index.