### PR TITLE
Initial support for ES aggregations

### DIFF
--- a/lib/exlasticsearch/aggregation.ex
+++ b/lib/exlasticsearch/aggregation.ex
@@ -1,0 +1,49 @@
+defmodule ExlasticSearch.Aggregation do
+  @moduledoc """
+  Elasticsearch aggregation building functions
+  """
+
+  defstruct [aggregations: [], nested: %{}, options: %{}]
+
+  @type t :: %__MODULE__{}
+
+  @doc "create a new aggregation specification"
+  def new(), do: %__MODULE__{}
+
+  @doc """
+  Bucket a query by a given term
+  """
+  def terms(%{aggregations: aggs} = agg, name, options) do
+    %{agg | aggregations: [{name, %{terms: Enum.into(options, %{})}} | aggs]}
+  end
+
+  @doc """
+  Return the top results for a query or aggregation scope
+  """
+  def top_hits(%{aggregations: aggs} = agg, name, options) do
+    %{agg | aggregations: [{name, %{top_hits: Enum.into(options, %{})}} | aggs]}
+  end
+
+  @doc """
+  Includes a given aggregation within the aggregation with name `name`
+  """
+  def nest(%{nested: nested} = agg, name, nest) do
+    %{agg | nested: Map.put(nested, name, nest)}
+  end
+
+  @doc """
+  Convert to the es representation of the aggregation
+  """
+  def realize(%__MODULE__{aggregations: aggs, nested: nested, options: opts}) do
+    %{aggs: Enum.into(aggs, %{}, fn {key, agg} -> {key, with_nested(realize(agg), nested, key)} end)
+            |> Map.merge(opts)}
+  end
+  def realize(map) when is_map(map), do: map
+
+  def with_nested(aggregation, nested, key) do
+    case nested do
+      %{^key => agg} -> Map.merge(realize(agg), aggregation)
+      _ -> aggregation
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Exlasticsearch.MixProject do
   use Mix.Project
 
-  @version "1.5.4"
+  @version "1.6.0"
 
   def project do
     [

--- a/test/support/test_model.ex
+++ b/test/support/test_model.ex
@@ -3,8 +3,9 @@ defmodule ExlasticSearch.TestModel do
   use ExlasticSearch.Model
 
   schema "test_models" do
-    field :name, :string
-    field :age, :integer, default: 0
+    field :name,  :string
+    field :age,   :integer, default: 0
+    field :group, :string
   end
 
   indexes :test_model do
@@ -13,6 +14,7 @@ defmodule ExlasticSearch.TestModel do
     options %{dynamic: :strict}
     mapping :name
     mapping :age
+    mapping :group, type: :keyword
 
     mapping :user, properties: %{ext_name: %{type: :text}}
   end


### PR DESCRIPTION

This gives us the following:

* an aggregation builder analogous to ExlasticSearch.Query
* a repo function that will exec the aggregation against a query,
and only return aggregation results for simplicity.

I still need to figure  out how to type these results, but since
it is driven by named keys, there's no proper schema.