### PR TITLE
Decode nested arrays

### DIFF
--- a/lib/exlasticsearch/model.ex
+++ b/lib/exlasticsearch/model.ex
@@ -199,5 +199,8 @@ defmodule ExlasticSearch.Model do
     end)
     |> Enum.into(%{})
   end
+  defp do_decode(template, source) when is_list(source) do
+    Enum.map(source, &do_decode(template, &1))
+  end
   defp do_decode(_, _), do: nil
 end

--- a/lib/exlasticsearch/response.ex
+++ b/lib/exlasticsearch/response.ex
@@ -17,7 +17,7 @@ defmodule ExlasticSearch.Response do
   This will define:
   * a struct for carrying the response
   * `parse/2` - converts a json decoded map from ES to the given response struct, and converting any models appropriately
-  * `to_model/2` - performs model conversion if possible (defaults to no-op) 
+  * `to_model/2` - performs model conversion if possible (defaults to no-op)
   """
   defmacro __using__(_) do
     quote do

--- a/test/exlasticsearch/model_test.exs
+++ b/test/exlasticsearch/model_test.exs
@@ -1,6 +1,8 @@
 defmodule ExlasticSearch.ModelTest do
   use ExUnit.Case, async: true
+
   alias ExlasticSearch.TestModel
+
   describe "ES Schema functions" do
     test "__doc_type__" do
       assert TestModel.__doc_type__() == :test_model
@@ -25,7 +27,7 @@ defmodule ExlasticSearch.ModelTest do
       assert val == :strict
     end
 
-    test "es_decode" do
+    test "es_decode with nested objects" do
       %TestModel.SearchResult{} = result = TestModel.es_decode(%{
         "name" => "some_name",
         "age" => 2,
@@ -37,6 +39,23 @@ defmodule ExlasticSearch.ModelTest do
       assert result.name == "some_name"
       assert result.age == 2
       assert result.user.ext_name == "other_name"
+    end
+
+    test "es_decode with nested arrays" do
+      %TestModel.SearchResult{} = result = TestModel.es_decode(%{
+        "name" => "some_name",
+        "age" => 2,
+        "user" => [
+          %{"ext_name" => "other_name"},
+          %{"ext_name" => "second_name"}
+        ]
+      })
+
+      assert result.name == "some_name"
+      assert result.age == 2
+      assert length(result.user) == 2
+      assert Enum.at(result.user, 0) == %{ext_name: "other_name"}
+      assert Enum.at(result.user, 1) == %{ext_name: "second_name"}
     end
 
     test "search_query" do


### PR DESCRIPTION
When decoding an ES response map into a index schema struct, we don't
explicitly handle nested arrays, so they are stripped out. A simple
update to `ExlasticSearch.Model.do_decode/2` fixes this bug.