### PR TITLE
Changes to allow updating of ElasticSearch documents and using a custom index

### DIFF
--- a/lib/exlasticsearch/bulk.ex
+++ b/lib/exlasticsearch/bulk.ex
@@ -1,0 +1,85 @@
+defmodule ExlasticSearch.BulkOperation do
+  @moduledoc """
+  Handles bulk request generation
+  """
+
+  alias ExlasticSearch.Indexable
+
+  @doc """
+  Generates a request for inserts, updates, nested property update and deletes
+  that can be sent as a bulk request using Elastix
+  """
+  def bulk_operation({:delete, _struct, _index} = instruction),
+    do: bulk_operation_delete(instruction)
+
+  def bulk_operation({:delete, struct}),
+    do: bulk_operation_delete({:delete, struct, :index})
+
+  def bulk_operation({:update, _struct, _id, _updates, _index} = instruction),
+    do: bulk_operation_update(instruction)
+
+  def bulk_operation({:update, struct, id, updates}),
+    do: bulk_operation_update({:update, struct, id, updates, :index})
+
+  def bulk_operation({:nested, _struct, _id, _source, _data, _index} = instruction),
+    do: bulk_operation_nested(instruction)
+
+  def bulk_operation({:nested, struct, id, source, data}),
+    do: bulk_operation_nested({:nested, struct, id, source, data, :index})
+
+  def bulk_operation({_op_type, _struct, _index} = instruction),
+    do: bulk_operation_default(instruction)
+
+  def bulk_operation({op_type, struct}),
+    do: bulk_operation_default({op_type, struct, :index})
+
+  defp bulk_operation_default({op_type, %{__struct__: model} = struct, index}) do
+    [
+      %{
+        op_type => %{
+          _id: Indexable.id(struct),
+          _index: model.__es_index__(index),
+          _type: model.__doc_type__()
+        }
+      },
+      build_document(struct, index)
+    ]
+  end
+
+  defp bulk_operation_nested({:nested, struct, id, source, data, index}) do
+    data = data |> Map.drop([:document_id])
+
+    [
+      %{
+        update: %{
+          _id: id,
+          _index: struct.__es_index__(index),
+          _type: struct.__doc_type__()
+        }
+      },
+      %{script: %{source: source, params: %{data: data}}}
+    ]
+  end
+
+  defp bulk_operation_update({:update, struct, id, updates, index}) do
+    [
+      %{update: %{_id: id, _index: struct.__es_index__(index), _type: struct.__doc_type__()}},
+      %{doc: updates}
+    ]
+  end
+
+  defp bulk_operation_delete({:delete, %{__struct__: model} = struct, index}) do
+    [
+      %{
+        delete: %{
+          _id: Indexable.id(struct),
+          _index: model.__es_index__(index),
+          _type: model.__doc_type__()
+        }
+      }
+    ]
+  end
+
+  defp build_document(struct, index),
+    do: struct |> Indexable.preload(index) |> Indexable.document(index)
+end

--- a/lib/exlasticsearch/indexable.ex
+++ b/lib/exlasticsearch/indexable.ex
@@ -9,10 +9,18 @@ defprotocol ExlasticSearch.Indexable do
   def id(_)
 
   @doc "Properties map to be inserted into ES"
+  @spec document(struct, atom) :: map
+  def document(_, _)
+
+  @doc "Properties map to be inserted into ES"
   @spec document(struct) :: map
   def document(_)
 
-  @doc "Any preloads needed to call `document/1`"
+  @doc "Any preloads needed to call `document/2`"
+  @spec preload(struct, atom) :: struct
+  def preload(_, _)
+
+  @doc "Any preloads needed to call `document/2`"
   @spec preload(struct) :: struct
   def preload(_)
 end

--- a/lib/exlasticsearch/model.ex
+++ b/lib/exlasticsearch/model.ex
@@ -81,9 +81,7 @@ defmodule ExlasticSearch.Model do
       def __es_index__(:read), do: index_version(unquote(type), @read_version)
       def __es_index__(:index), do: index_version(unquote(type), @index_version)
       def __es_index__(:delete), do: __es_index__(:read)
-      def __es_index__(:read_sync_test), do: __es_index__(:read) <> "_sync"
-      def __es_index__(:index_sync_test), do: __es_index__(:index) <> "_sync"
-      def __es_index__(_), do: __es_index__(:read)
+      def __es_index__(custom_index), do: "#{unquote(type)}_#{custom_index}"
 
       def __es_mappings__() do
         @mapping_options

--- a/lib/exlasticsearch/repo.ex
+++ b/lib/exlasticsearch/repo.ex
@@ -17,7 +17,8 @@ defmodule ExlasticSearch.Repo do
 
   @chunk_size 2000
   @type response :: {:ok, %HTTPoison.Response{}} | {:error, any}
-  @log_level Application.get_env(:exlasticsearch, __MODULE__, []) |> Keyword.get(:log_level, :debug)
+  @log_level Application.get_env(:exlasticsearch, __MODULE__, [])
+             |> Keyword.get(:log_level, :debug)
 
   @doc """
   Creates an index as defined in `model`
@@ -31,24 +32,24 @@ defmodule ExlasticSearch.Repo do
   @doc """
   Updates the index for `model`
   """
-  def update_index(model) do
-    url = es_url() <> "/#{model.__es_index__(:index)}/_settings"
+  def update_index(model, index \\ :index) do
+    url = es_url() <> "/#{model.__es_index__(index)}/_settings"
     HTTP.put(url, Poison.encode!(model.__es_settings__()))
   end
 
   @doc """
   Close an index for `model`
   """
-  def close_index(model) do
-    url = es_url() <> "/#{model.__es_index__(:index)}/_close"
+  def close_index(model, index \\ :index) do
+    url = es_url() <> "/#{model.__es_index__(index)}/_close"
     HTTP.post(url, "")
   end
 
   @doc """
   open an index for `model`
   """
-  def open_index(model) do
-    url = es_url() <> "/#{model.__es_index__(:index)}/_open"
+  def open_index(model, index \\ :index) do
+    url = es_url() <> "/#{model.__es_index__(index)}/_open"
     HTTP.post(url, "")
   end
 
@@ -83,18 +84,20 @@ defmodule ExlasticSearch.Repo do
   @spec create_alias(atom, [{atom, atom}]) :: response
   def create_alias(model, [{from, target}]) do
     url = "#{es_url()}/_aliases"
-    from_index   = model.__es_index__(from)
+    from_index = model.__es_index__(from)
     target_index = model.__es_index__(target)
-    json = Poison.encode!(%{
-      actions: [
-        %{
-          add: %{
-            index: from_index,
-            alias: target_index
-          },
-        }
-      ]
-    })
+
+    json =
+      Poison.encode!(%{
+        actions: [
+          %{
+            add: %{
+              index: from_index,
+              alias: target_index
+            }
+          }
+        ]
+      })
 
     HTTP.post(url, json)
   end
@@ -102,11 +105,11 @@ defmodule ExlasticSearch.Repo do
   @doc """
   Deletes the read index and aliases the write index to it
   """
-  @spec rotate(atom) :: response
-  def rotate(model) do
-    with false <- model.__es_index__(:read) == model.__es_index__(:index),
-         _result <- delete_index(model, :read),
-      do: create_alias(model, index: :read)
+  @spec rotate(atom, atom, atom) :: response
+  def rotate(model, read \\ :read, index \\ :index) do
+    with false <- model.__es_index__(read) == model.__es_index__(index),
+         _result <- delete_index(model, read),
+         do: create_alias(model, index: read)
   end
 
   @doc """
@@ -136,9 +139,9 @@ defmodule ExlasticSearch.Repo do
   @doc """
   Refreshes `model`'s index
   """
-  def refresh(model) do
+  def refresh(model, index \\ :read) do
     es_url()
-    |> Index.refresh(model.__es_index__())
+    |> Index.refresh(model.__es_index__(index))
   end
 
   @doc """
@@ -147,12 +150,38 @@ defmodule ExlasticSearch.Repo do
   """
   @spec index(struct) :: response
   @decorate retry()
-  def index(%{__struct__: model} = struct) do
+  def index(%{__struct__: model} = struct, index \\ :index) do
     id = Indexable.id(struct)
-    document = build_document(struct)
+    document = build_document(struct, index)
 
     es_url()
-    |> Document.index(model.__es_index__(:index), model.__doc_type__(), id, document)
+    |> Document.index(model.__es_index__(index), model.__doc_type__(), id, document)
+    |> log_response()
+    |> mark_failure()
+  end
+
+  @doc """
+  Updates the document of the passed in id for the index associated to the model
+  """
+  @decorate retry()
+  def update(model, id, updates, index \\ :index) do
+    es_url()
+    |> Document.update(model.__es_index__(index), model.__doc_type__(), id, %{doc: updates})
+    |> log_response()
+    |> mark_failure()
+  end
+
+  @doc """
+  Updates a nested field of the document of the passed in id for the index associated to the model.
+
+  the source param is the script you want to apply for the update.
+  """
+  @decorate retry()
+  def update_nested(model, id, source, updates, index \\ :index) do
+    es_url()
+    |> Document.update(model.__es_index__(index), model.__doc_type__(), id, %{
+      script: %{source: source, params: %{data: updates}}
+    })
     |> log_response()
     |> mark_failure()
   end
@@ -171,7 +200,7 @@ defmodule ExlasticSearch.Repo do
   @doc """
   Creates a call to `search/3` by realizing `query` (using `Exlasticsearch.Query.realize/1`) and any provided search opts
   """
-  @spec search(Query.t, list) :: response
+  @spec search(Query.t(), list) :: response
   def search(%Query{queryable: model} = query, params),
     do: search(model, Query.realize(query), params, query.index_type || :read)
 
@@ -193,11 +222,13 @@ defmodule ExlasticSearch.Repo do
     search =
       Query.realize(query)
       |> Map.merge(Aggregation.realize(aggregation))
+
     index_type = query.index_type || :read
 
     es_url()
     |> Search.search(model.__es_index__(index_type), [model.__doc_type__()], search, size: 0)
-    |> log_response() # TODO: figure out how to decode these, it's not trivial to type them
+    # TODO: figure out how to decode these, it's not trivial to type them
+    |> log_response()
   end
 
   @doc """
@@ -205,22 +236,23 @@ defmodule ExlasticSearch.Repo do
   """
   @spec delete(struct) :: response
   @decorate retry()
-  def delete(%{__struct__: model} = struct) do
+  def delete(%{__struct__: model} = struct, index \\ :index) do
     es_url()
-    |> Document.delete(model.__es_index__(:index), model.__doc_type__(), Indexable.id(struct))
+    |> Document.delete(model.__es_index__(index), model.__doc_type__(), Indexable.id(struct))
     |> log_response()
     |> mark_failure()
   end
 
-
   @doc """
   Generates an Elasticsearch bulk request. `operations` should be of the form:
 
+  Note: the last element in each Tuple is optional and will default to :index
   ```
   [
-    {:index, struct},
-    {:delete, other_struct},
-    {:update, third_struct}
+    {:index, struct, index},
+    {:delete, other_struct, index},
+    {:update, third_struct, id, map, index},
+    {:nested, id, source, map, index}
   ]
   ```
 
@@ -228,9 +260,10 @@ defmodule ExlasticSearch.Repo do
   struct to the `ExlasticSearch.Indexable` protocol
   """
   def bulk(operations, opts \\ []) do
-    bulk_request = operations
-                   |> Enum.map(&bulk_operation/1)
-                   |> Enum.concat()
+    bulk_request =
+      operations
+      |> Enum.map(&bulk_operation/1)
+      |> Enum.concat()
 
     es_url()
     |> Bulk.post(bulk_request, [], opts)
@@ -238,16 +271,16 @@ defmodule ExlasticSearch.Repo do
     |> mark_failure()
   end
 
-  def index_stream(stream, parallelism \\ 10, demand \\ 10) do
+  def index_stream(stream, index \\ :index, parallelism \\ 10, demand \\ 10) do
     stream
     |> Stream.chunk_every(@chunk_size)
     |> Flow.from_enumerable(stages: parallelism, max_demand: demand)
-    |> Flow.map(&insert_chunk/1)
+    |> Flow.map(&insert_chunk(&1, index))
   end
 
-  defp insert_chunk(chunk) do
+  defp insert_chunk(chunk, index) do
     chunk
-    |> Enum.map(& {:index, &1})
+    |> Enum.map(&{:index, &1, index})
     |> bulk()
 
     length(chunk)
@@ -258,16 +291,79 @@ defmodule ExlasticSearch.Repo do
     response
   end
 
-  defp bulk_operation({:delete, %{__struct__: model} = struct}),
-    do: [%{delete: %{_id: Indexable.id(struct), _index: model.__es_index__(:index), _type: model.__doc_type__()}}]
-  defp bulk_operation({op_type, %{__struct__: model} = struct}) do
+  defp bulk_operation({:delete, _struct, _index} = instruction),
+    do: bulk_operation_delete(instruction)
+
+  defp bulk_operation({:delete, struct}),
+    do: bulk_operation_delete({:delete, struct, :index})
+
+  defp bulk_operation({:update, _struct, _id, _updates, _index} = instruction),
+    do: bulk_operation_update(instruction)
+
+  defp bulk_operation({:update, struct, id, updates}),
+    do: bulk_operation_update({:update, struct, id, updates, :index})
+
+  defp bulk_operation({:nested, _struct, _id, _source, _data, _index} = instruction),
+    do: bulk_operation_nested(instruction)
+
+  defp bulk_operation({:nested, struct, id, source, data}),
+    do: bulk_operation_nested({:nested, struct, id, source, data, :index})
+
+  defp bulk_operation({_op_type, _struct, _index} = instruction),
+    do: bulk_operation_default(instruction)
+
+  defp bulk_operation({op_type, struct}),
+    do: bulk_operation_default({op_type, struct, :index})
+
+  defp bulk_operation_default({op_type, %{__struct__: model} = struct, index}) do
     [
-      %{op_type => %{_id: Indexable.id(struct), _index: model.__es_index__(:index), _type: model.__doc_type__()}},
-      build_document(struct)
+      %{
+        op_type => %{
+          _id: Indexable.id(struct),
+          _index: model.__es_index__(index),
+          _type: model.__doc_type__()
+        }
+      },
+      build_document(struct, index)
     ]
   end
 
-  defp build_document(struct), do: struct |> Indexable.preload() |> Indexable.document()
+  defp bulk_operation_nested({:nested, struct, id, source, data, index}) do
+    data = data |> Map.drop([:document_id])
+
+    [
+      %{
+        update: %{
+          _id: id,
+          _index: struct.__es_index__(index),
+          _type: struct.__doc_type__()
+        }
+      },
+      %{script: %{source: source, params: %{data: data}}}
+    ]
+  end
+
+  defp bulk_operation_update({:update, struct, id, updates, index}) do
+    [
+      %{update: %{_id: id, _index: struct.__es_index__(index), _type: struct.__doc_type__()}},
+      %{doc: updates}
+    ]
+  end
+
+  defp bulk_operation_delete({:delete, %{__struct__: model} = struct, index}) do
+    [
+      %{
+        delete: %{
+          _id: Indexable.id(struct),
+          _index: model.__es_index__(index),
+          _type: model.__doc_type__()
+        }
+      }
+    ]
+  end
+
+  defp build_document(struct, index),
+    do: struct |> Indexable.preload(index) |> Indexable.document(index)
 
   defp es_url(), do: Application.get_env(:exlasticsearch, __MODULE__)[:url]
 
@@ -277,9 +373,16 @@ defmodule ExlasticSearch.Repo do
       result -> {:ok, result}
     end
   end
+
   defp decode(response, _, _), do: response
 
-  defp mark_failure({:ok, %HTTPoison.Response{body: %{"_shards" => %{"successful" => 0}}} = result}), do: {:error, result}
-  defp mark_failure({:ok, %HTTPoison.Response{body: %{"errors" => true}} = result}), do: {:error, result}
+  defp mark_failure(
+         {:ok, %HTTPoison.Response{body: %{"_shards" => %{"successful" => 0}}} = result}
+       ),
+       do: {:error, result}
+
+  defp mark_failure({:ok, %HTTPoison.Response{body: %{"errors" => true}} = result}),
+    do: {:error, result}
+
   defp mark_failure(result), do: result
 end

--- a/test/support/test_model.ex
+++ b/test/support/test_model.ex
@@ -62,11 +62,11 @@ defimpl ExlasticSearch.Indexable,
   for: [ExlasticSearch.TestModel, ExlasticSearch.MultiVersionTestModel] do
   def id(%{id: id}), do: id
 
-  def document(struct) do
+  def document(struct, _) do
     struct
     |> Map.from_struct()
     |> Map.take(@for.__mappings__())
   end
 
-  def preload(struct), do: struct
+  def preload(struct, _), do: struct
 end

--- a/test/support/test_model.ex
+++ b/test/support/test_model.ex
@@ -3,20 +3,29 @@ defmodule ExlasticSearch.TestModel do
   use ExlasticSearch.Model
 
   schema "test_models" do
-    field :name,  :string
-    field :age,   :integer, default: 0
-    field :group, :string
+    field(:name, :string)
+    field(:age, :integer, default: 0)
+    field(:group, :string)
+    field(:teams, {:array, :map})
   end
 
   indexes :test_model do
-    versions 2
-    settings %{}
-    options %{dynamic: :strict}
-    mapping :name
-    mapping :age
-    mapping :group, type: :keyword
+    versions(2)
+    settings(%{})
+    options(%{dynamic: :strict})
+    mapping(:name)
+    mapping(:age)
+    mapping(:group, type: :keyword)
 
-    mapping :user, properties: %{ext_name: %{type: :text}}
+    mapping(:user, properties: %{ext_name: %{type: :text}})
+
+    mapping(:teams,
+      type: :nested,
+      properties: %{
+        name: %{type: :keyword},
+        rating: %{type: :integer}
+      }
+    )
   end
 end
 
@@ -25,22 +34,32 @@ defmodule ExlasticSearch.MultiVersionTestModel do
   use ExlasticSearch.Model
 
   schema "mv_models" do
-    field :name, :string
-    field :age, :integer, default: 0
+    field(:name, :string)
+    field(:age, :integer, default: 0)
+    field(:teams, {:array, :map})
   end
 
   indexes :multiversion_model do
-    versions {:ignore, 2}
-    settings %{}
-    options %{dynamic: :strict}
-    mapping :name
-    mapping :age
+    versions({:ignore, 2})
+    settings(%{})
+    options(%{dynamic: :strict})
+    mapping(:name)
+    mapping(:age)
 
-    mapping :user, properties: %{ext_name: %{type: :text}}
+    mapping(:user, properties: %{ext_name: %{type: :text}})
+
+    mapping(:teams,
+      type: :nested,
+      properties: %{
+        name: %{type: :keyword},
+        rating: %{type: :integer}
+      }
+    )
   end
 end
 
-defimpl ExlasticSearch.Indexable, for: [ExlasticSearch.TestModel, ExlasticSearch.MultiVersionTestModel] do
+defimpl ExlasticSearch.Indexable,
+  for: [ExlasticSearch.TestModel, ExlasticSearch.MultiVersionTestModel] do
   def id(%{id: id}), do: id
 
   def document(struct) do


### PR DESCRIPTION
- Adds an update function to support the ability to do updates to documents instead of
  only indexing

- Adds a function to enable updating a nested property of a document

- Extends the bulk function to support updating a document and updating a nested field
  in a document

- Edit all functions to optionally take in an atom to determine the index to use for the operation

- Edit the Indexable protocol for functions preload and document so that they now optionally take in
  the index so that different actions can be taken on different indexes.