### PR TITLE
Add the ability to query across multiple indexes.

### DIFF
--- a/lib/exlasticsearch/response.ex
+++ b/lib/exlasticsearch/response.ex
@@ -23,29 +23,29 @@ defmodule ExlasticSearch.Response do
     quote do
       import ExlasticSearch.Response
 
-      def parse(record, model) do
+      def parse(record, model, index_type) do
         __schema__(:parse_spec)
         |> convert_keys(record)
-        |> parse_associations(__schema__(:associations), model)
-        |> to_model(model)
+        |> parse_associations(__schema__(:associations), model, index_type)
+        |> to_model(model, index_type)
         |> new()
       end
 
-      def to_model(struct, model), do: struct
+      def to_model(struct, model, index_type), do: struct
 
       def new(map), do: struct(__MODULE__, map)
 
-      defoverridable [to_model: 2]
+      defoverridable [to_model: 3]
     end
   end
 
   @doc """
   Utility for recursively parsing response associations
   """
-  def parse_associations(response, associations, model) do
+  def parse_associations(response, associations, model, index_type) do
     associations
     |> Enum.map(fn {type, field, parser} ->
-      {field, parse_assoc(type, response[field], &parser.parse(&1, model))}
+      {field, parse_assoc(type, response[field], &parser.parse(&1, model, index_type))}
     end)
     |> Enum.into(response)
   end

--- a/lib/exlasticsearch/response/record.ex
+++ b/lib/exlasticsearch/response/record.ex
@@ -9,7 +9,19 @@ defmodule ExlasticSearch.Response.Record do
     field :_id
     field :_source
     field :found
+    field :_index
   end
 
-  def to_model(%{_source: source} = record, model), do: %{record | _source: model.es_decode(source)}
+  def to_model(%{_source: source, _index: index} = record, model, index_type) do
+    source_model = source_model(model, index, index_type)
+
+    %{record | _source: source_model.es_decode(source)}
+  end
+
+  defp source_model(models, index, index_type) when is_list(models) do
+    models
+    |> Enum.find(& &1.__es_index__(index_type) == index)
+  end
+  defp source_model(model, _, _), do: model
+
 end

--- a/test/support/test_model.ex
+++ b/test/support/test_model.ex
@@ -29,6 +29,22 @@ defmodule ExlasticSearch.TestModel do
   end
 end
 
+defmodule ExlasticSearch.TestModel2 do
+  use Ecto.Schema
+  use ExlasticSearch.Model
+
+  schema "test_models2" do
+    field(:name, :string)
+  end
+
+  indexes :test_model2 do
+    versions(2)
+    settings(%{})
+    options(%{dynamic: :strict})
+    mapping(:name)
+  end
+end
+
 defmodule ExlasticSearch.MultiVersionTestModel do
   use Ecto.Schema
   use ExlasticSearch.Model
@@ -59,7 +75,7 @@ defmodule ExlasticSearch.MultiVersionTestModel do
 end
 
 defimpl ExlasticSearch.Indexable,
-  for: [ExlasticSearch.TestModel, ExlasticSearch.MultiVersionTestModel] do
+  for: [ExlasticSearch.TestModel, ExlasticSearch.TestModel2, ExlasticSearch.MultiVersionTestModel] do
   def id(%{id: id}), do: id
 
   def document(struct, _) do


### PR DESCRIPTION
Within `ExlasticSearch.Query` the `queryable` field now takes an array of
models representing each of the indexes that should be queried.