### PR TITLE
When calling `index_stream` the index which is used to determine which

### DIFF
--- a/lib/exlasticsearch/repo.ex
+++ b/lib/exlasticsearch/repo.ex
@@ -298,7 +298,7 @@ defmodule ExlasticSearch.Repo do
   defp insert_chunk(chunk, index) do
     chunk
     |> Enum.map(&{:index, &1, index})
-    |> bulk()
+    |> bulk(index)
 
     length(chunk)
   end


### PR DESCRIPTION
ES url to send the request to was not passed allong to the `bulk/3` function
so the url always defaulted to the default one.