### PR TITLE
Add Ecto.Enum type inference and map to :keyword

### DIFF
--- a/lib/exlasticsearch/type_inference/base.ex
+++ b/lib/exlasticsearch/type_inference/base.ex
@@ -11,6 +11,7 @@ defmodule ExlasticSearch.TypeInference.Base do
       def infer(:float), do: :double
       def infer(:string), do: :text
       def infer(:binary), do: :text
+      def infer(Ecto.Enum), do: :keyword
       def infer(dt) when dt in [Ecto.DateTime, Timex.Ecto.DateTime, :utc_datetime], do: :date
       def infer(type), do: type
 


### PR DESCRIPTION
This adds a new mapping for Ecto.Enum types and maps them to an ElasticSearch keyword.